### PR TITLE
test: add contact form submission test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  testEnvironment: 'jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "react": "19.1.0",
@@ -18,6 +19,10 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.4",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/src/components/__tests__/Contact.test.js
+++ b/src/components/__tests__/Contact.test.js
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import Contact from '../Contact';
+
+describe('Contact', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows confirmation message and hides it after 4 seconds', () => {
+    render(<Contact />);
+
+    fireEvent.change(screen.getByLabelText(/Nom/i), {
+      target: { value: 'John Doe' },
+    });
+    fireEvent.change(screen.getByLabelText(/Email/i), {
+      target: { value: 'john@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/Message/i), {
+      target: { value: 'Hello' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Envoyer/i }));
+
+    expect(screen.getByText(/Merci pour votre message/i)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(screen.queryByText(/Merci pour votre message/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest and Testing Library for the Next.js project
- add Contact form test verifying confirmation message disappears after 4 seconds

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a8f5cf44832991476453125d2f0b