### PR TITLE
Fix audience list class casing

### DIFF
--- a/src/components/Audience.js
+++ b/src/components/Audience.js
@@ -36,7 +36,7 @@ export default function Audience() {
             <div key={index} className={styles.card}>
               <div className={styles.icon}>{cat.icon}</div>
               <h3>{cat.title}</h3>
-              <ul>
+              <ul className={styles.audienceList}>
                 {cat.items.map((item, idx) => (
                   <li key={idx}>{item}</li>
                 ))}

--- a/src/styles/Audience.module.css
+++ b/src/styles/Audience.module.css
@@ -34,17 +34,17 @@
   color: var(--primary-color);
 }
 
-.audienceList ul {
+.audienceList {
   list-style: none;
   padding: 0;
 }
 
-.audiencelist li {
+.audienceList li {
   margin-bottom: 0.5rem;
   padding-left: 1.25rem;
 }
 
-.audiencelist li::before {
+.audienceList li::before {
   content: '•';
   position: absolute;
   left: 0;


### PR DESCRIPTION
## Summary
- rename `audiencelist` class selectors to `audienceList` in Audience module
- apply `styles.audienceList` class to Audience list element

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` and `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_6894a8f1f5188329acd8c715e483bf44