### PR TITLE
Style hero link as button and fix build font

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,15 +1,4 @@
-import { Geist, Geist_Mono } from "next/font/google";
 import '../styles/globals.css';
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata = {
   title: "Create Next App",
@@ -19,9 +8,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -19,8 +19,9 @@ export default function Hero() {
           href="https://www.lydia-app.com/"
           target="_blank"
           rel="noopener noreferrer"
+          className={styles.ctaButton}
         >
-          <button>Créer ma cagnotte</button>
+          Créer ma cagnotte
         </a>
       </div>
     </section>

--- a/src/styles/Hero.module.css
+++ b/src/styles/Hero.module.css
@@ -41,3 +41,21 @@
 .hero p {
   margin-bottom: 2rem;
 }
+
+.ctaButton {
+  display: inline-block;
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  font-family: var(--font-sans);
+}
+
+.ctaButton:hover,
+.ctaButton:focus {
+  background-color: var(--primary-dark);
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- replace nested button in hero with styled anchor link
- add CTA button styling for hero anchor
- remove external Geist font and references so build no longer fetches Google fonts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894a8f385408329b312252ac910d8aa